### PR TITLE
Toolchain versions

### DIFF
--- a/Toolchain-versions.md
+++ b/Toolchain-versions.md
@@ -1,9 +1,8 @@
 
-
 [gompi](#gompi)  
-[goolf](#gooofl)  
 
-<!-
+
+<!---
 ## ClangGCC: Clang, GCC
 
 
@@ -58,15 +57,9 @@
 <a name="gompi"/>
 ## gompi: GCC, OpenMPI
 
-| gompi          | GCC         | OpenMPI       |
-| -------------- | ----------- | ------------- |
-| 1.1.0          | 4.6.3       | 1.4.5         |
-| 1.3.12         | 4.6.4       | 1.6.4         |
-| 1.4.10         | 4.7.2       | 1.6.4         |
-| 1.5.12         | 4.8.1       | 1.6.5         |
-| 1.5.12-no-OFED | 4.8.1       | 1.6.5-no-OFED |
 
-
+| gompi                | GCC             | OpenMPI               |
+| -------------------- | --------------- | --------------------- |
 | gompi-1.1.0          | GCC-4.6.3       | OpenMPI-1.4.5         |
 | gompi-1.3.12         | GCC-4.6.4       | OpenMPI-1.6.4         |
 | gompi-1.4.10         | GCC-4.7.2       | OpenMPI-1.6.4         |
@@ -74,7 +67,7 @@
 | gompi-1.5.12-no-OFED | GCC-4.8.1       | OpenMPI-1.6.5-no-OFED |
 
 
-<!-
+<!---
 ## goolf: BLACS, FFTW, GCC, OpenBLAS, OpenMPI, ScaLAPACK
 
 

--- a/Toolchain-versions.md
+++ b/Toolchain-versions.md
@@ -1,17 +1,38 @@
+# Toolchain Versions
 
+
+This page keeps track of the existing toolchains and gives the details of each version.
+
+
+[ClangGCC](#clanggcc)  
+[cgmpich](#cgmpich)  
 [gompi](#gompi)  
 
 
-<!---
+<a name="clanggcc"/>
 ## ClangGCC: Clang, GCC
 
 
+| ClangGCC             | GCC             | Clang        |
+| -------------------- | --------------- | ------------ |
+| ClangGCC-1.1.3       | GCC-4.7.3       | Clang-3.2    |
+| ClangGCC-1.2.3       | GCC-4.8.1       | Clang-3.3    |
+
+
+<!---
 ## GCC: GCC
+-->
 
 
 ## cgmpich: ClangGCC, MPICH
 
 
+| cgmpich       | ClangGCC        | MPICH        |
+| ------------- | --------------- | ------------ |
+| cgmpich-1.1.6 | ClangGCC-1.1.3  | MPICH-3.0.3  |
+
+
+<!---
 ## cgmpolf: BLACS, ClangGCC, FFTW, MPICH, OpenBLAS, ScaLAPACK
 
 

--- a/Toolchain-versions.md
+++ b/Toolchain-versions.md
@@ -1,0 +1,105 @@
+
+
+[gompi](#gompi)  
+[goolf](#gooofl)  
+
+<!-
+## ClangGCC: Clang, GCC
+
+
+## GCC: GCC
+
+
+## cgmpich: ClangGCC, MPICH
+
+
+## cgmpolf: BLACS, ClangGCC, FFTW, MPICH, OpenBLAS, ScaLAPACK
+
+
+## cgmvapich2: ClangGCC, MVAPICH2
+
+
+## cgmvolf: BLACS, ClangGCC, FFTW, MVAPICH2, OpenBLAS, ScaLAPACK
+
+
+## cgompi: ClangGCC, OpenMPI
+
+
+## cgoolf: BLACS, ClangGCC, FFTW, OpenBLAS, OpenMPI, ScaLAPACK
+
+
+## dummy: 
+
+
+## gcccuda: CUDA, GCC
+
+
+## gimkl: GCC, imkl, impi
+
+
+## gmacml: ACML, BLACS, FFTW, GCC, MVAPICH2, ScaLAPACK
+
+
+## gmpich2: GCC, MPICH2
+
+
+## gmpolf: BLACS, FFTW, GCC, MPICH2, OpenBLAS, ScaLAPACK
+
+
+## gmvapich2: GCC, MVAPICH2
+
+
+## gmvolf: BLACS, FFTW, GCC, MVAPICH2, OpenBLAS, ScaLAPACK
+
+
+## goalf: ATLAS, BLACS, FFTW, GCC, OpenMPI, ScaLAPACK
+-->
+
+<a name="gompi"/>
+## gompi: GCC, OpenMPI
+
+| gompi          | GCC         | OpenMPI       |
+| -------------- | ----------- | ------------- |
+| 1.1.0          | 4.6.3       | 1.4.5         |
+| 1.3.12         | 4.6.4       | 1.6.4         |
+| 1.4.10         | 4.7.2       | 1.6.4         |
+| 1.5.12         | 4.8.1       | 1.6.5         |
+| 1.5.12-no-OFED | 4.8.1       | 1.6.5-no-OFED |
+
+
+| gompi-1.1.0          | GCC-4.6.3       | OpenMPI-1.4.5         |
+| gompi-1.3.12         | GCC-4.6.4       | OpenMPI-1.6.4         |
+| gompi-1.4.10         | GCC-4.7.2       | OpenMPI-1.6.4         |
+| gompi-1.5.12         | GCC-4.8.1       | OpenMPI-1.6.5         |
+| gompi-1.5.12-no-OFED | GCC-4.8.1       | OpenMPI-1.6.5-no-OFED |
+
+
+<!-
+## goolf: BLACS, FFTW, GCC, OpenBLAS, OpenMPI, ScaLAPACK
+
+
+## goolfc: BLACS, CUDA, FFTW, GCC, OpenBLAS, OpenMPI, ScaLAPACK
+
+
+## gqacml: ACML, BLACS, FFTW, GCC, QLogicMPI, ScaLAPACK
+
+
+## iccifort: icc, ifort
+
+
+## ictce: icc, ifort, imkl, impi
+
+
+## iiqmpi: QLogicMPI, icc, ifort
+
+
+## iomkl: OpenMPI, icc, ifort, imkl
+
+
+## iqacml: ACML, BLACS, FFTW, QLogicMPI, ScaLAPACK, icc, ifort
+
+
+## ismkl: MPICH2, icc, ifort, imkl
+
+
+-->


### PR DESCRIPTION
I don't know any good way to quickly see which versions of a compiler/library is used in a given toolchain. Is there? I know I can look in the easyconfig file, but I don't think it is really convenient. Specially because I would to see all of them at once, in order to keep track of the versioning.

So I propose to document this in the wiki. This new page is a tentative page to show what it could look like.
If it is accepted, it needs to be completed for all the available toolchains. Then it will have to be updated each time a new toolchain version is created.
